### PR TITLE
Update webpacker config to support stylesheets

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,1 +1,2 @@
+<%= stylesheet_pack_tag 'index' %>
 <%= javascript_pack_tag 'index' %>

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg


### PR DESCRIPTION
In this commit, we add the stylesheet_pack_tag to include css file in our index.html. This is an attempt to fix the problem of not importing the ant design css in production.