### PR TITLE
Add initial home warning on first visit

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -55,3 +55,23 @@
     font-size: 30px;
     margin: 0 20px;
 }
+
+.home-warning-container {
+    text-align: center;
+}
+
+.home-warning-close-icon {
+    color: lightGray !important;
+    font-size: 25px;
+    font-weight: bold;
+}
+
+.home-warning-content-wrapper {
+    padding: 30px;
+    text-align: justify;
+    font-size: 18px;
+}
+
+.home-warning-footer-wrapper {
+    padding-bottom: 40px;
+}

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,6 +1,7 @@
 // Place all the styles related to the home controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+@import './common/colors';
 
 .home-join {
     display: flex;
@@ -61,7 +62,7 @@
 }
 
 .home-warning-close-icon {
-    color: lightGray !important;
+    color: $darkGrey !important;
     font-size: 25px;
     font-weight: bold;
 }

--- a/app/javascript/components/common/hooks/useLocalStorage.js
+++ b/app/javascript/components/common/hooks/useLocalStorage.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+// Based on https://usehooks.com/useLocalStorage/
+
+export default function useLocalStorage(key, initialValue) {
+    // State to store our value
+    // Pass initial state function to useState so logic is only executed once
+    const [storedValue, setStoredValue] = useState(() => {
+        try {
+            // Get from local storage by key
+            const item = window.localStorage.getItem(key);
+            // Parse stored json or if none return initialValue
+            return item ? JSON.parse(item) : initialValue;
+        } catch (error) {
+            // If error also return initialValue
+            console.log(error);
+            return initialValue;
+        }
+    });
+
+    // Return a wrapped version of useState's setter function that ...
+    // ... persists the new value to localStorage.
+    const setValue = value => {
+        try {
+            // Allow value to be a function so we have same API as useState
+            const valueToStore =
+                value instanceof Function ? value(storedValue) : value;
+            // Save state
+            setStoredValue(valueToStore);
+            // Save to local storage
+            window.localStorage.setItem(key, JSON.stringify(valueToStore));
+        } catch (error) {
+            // A more advanced implementation would handle the error case
+            console.log(error);
+        }
+    };
+
+    return [storedValue, setValue];
+}

--- a/app/javascript/components/home/HomeInitialWarning.js
+++ b/app/javascript/components/home/HomeInitialWarning.js
@@ -1,0 +1,31 @@
+import React from "react";
+import {Button, Icon, Modal} from "antd";
+import useLocalStorage from "../common/hooks/useLocalStorage";
+
+
+export default function HomeInitialWarning() {
+
+    const [firstTime, setFirstTime] = useLocalStorage('firstTime', true);
+
+    return (
+        <Modal
+            visible={firstTime}
+            footer={null}
+            className="home-warning-container"
+            onCancel={() => setFirstTime(false)}
+            maskClosable={false}
+            closeIcon={
+                <Icon className="home-warning-close-icon" type="close-circle" theme="filled"/>
+            }
+        >
+            <h1>Atenção!</h1>
+            <div className="home-warning-content-wrapper">
+                <p>Neste momento, esta plataforma ainda não se encontra 100% completa.</p>
+                <p>Estamos a processar alguns dos programas eleitorais e à espera que as restantes candidaturas disponibilizem a respectiva informação.</p>
+            </div>
+            <div className="home-warning-footer-wrapper">
+                <Button onClick={() => setFirstTime(false)} style={{backgroundColor: 'lightGray', color: 'white', fontWeight: 'bold'}}>Compreendi!</Button>
+            </div>
+        </Modal>
+    )
+}

--- a/app/javascript/components/home/HomeInitialWarning.js
+++ b/app/javascript/components/home/HomeInitialWarning.js
@@ -24,7 +24,7 @@ export default function HomeInitialWarning() {
                 <p>Estamos a processar alguns dos programas eleitorais e à espera que as restantes candidaturas disponibilizem a respectiva informação.</p>
             </div>
             <div className="home-warning-footer-wrapper">
-                <Button onClick={() => setFirstTime(false)} style={{backgroundColor: 'lightGray', color: 'white', fontWeight: 'bold'}}>Compreendi!</Button>
+                <Button onClick={() => setFirstTime(false)} className="button--grey">Compreendi!</Button>
             </div>
         </Modal>
     )

--- a/app/javascript/components/home/index.js
+++ b/app/javascript/components/home/index.js
@@ -7,6 +7,7 @@ import HomePartiesList from "./HomePartiesList";
 import HomeMovement from "./HomeMovement";
 import PARTIES_LIST from '../../dummy-parties';
 import { shuffleArray } from '../../utils';
+import HomeInitialWarning from "./HomeInitialWarning";
 
 class Home extends PureComponent {
     constructor() {
@@ -24,6 +25,7 @@ class Home extends PureComponent {
             <Layout>
                 <LayoutHeader />
                 <Layout.Content>
+                    <HomeInitialWarning />
                     <HomeMission />
                     <HomePartiesList parties={parties} />
                     <HomeMovement />


### PR DESCRIPTION
Add initial home warning on first visit.

This implementation relies on the browser localStorage in order to show the warning modal only on the first access.

![Screenshot from 2019-09-18 23-18-57](https://user-images.githubusercontent.com/1140720/65191080-c51e5a00-da6a-11e9-9278-a7b8b7c91d23.png)

Missing: according to figma mockups the close icon should be black.

Steps to test: clear localstorage after first visit or set the state always to true in: HomeInitialWarning 

