### PR TITLE
Fix party email link

### DIFF
--- a/app/javascript/components/common/SocialSharing.js
+++ b/app/javascript/components/common/SocialSharing.js
@@ -18,12 +18,20 @@ import React from "react";
 import PropTypes from 'prop-types';
 import SocialIcon from "./SocialIcon";
 
+function getHrefFromUrl(type, url) {
+    if (type === 'email') {
+        return `mailto:${url}`;
+    }
+
+    return url;
+}
+
 const SocialSharing = ({ socialMediaList = [], theme }) => {
     return (
         <ul className="social-media-list">
             {socialMediaList.map((social, index) => (
                 <li key={index}>
-                    <a href={social.url} target="_blank" rel="noopener">
+                    <a href={getHrefFromUrl(social.type, social.url)} target="_blank" rel="noopener">
                         <SocialIcon icon={social.type} theme={theme} />
                     </a>
                 </li>


### PR DESCRIPTION
In this commit, we fix the party email link. Previously we were assuming that the email link was a normal link, but now we prefix it with `mailto` to open the default email application.

Closes #105 