### PR TITLE
added hover option on party_candidate__content .

### DIFF
--- a/app/assets/stylesheets/pages/party-detail/_party-candidates.scss
+++ b/app/assets/stylesheets/pages/party-detail/_party-candidates.scss
@@ -37,6 +37,9 @@
         @media only screen and (min-width: 992px) {
             max-width: 220px;
         }
+        &:hover {
+            opacity: 0.7;
+        }
     }
 
     .party-candidate__content-title.ant-typography {


### PR DESCRIPTION
added a quick hover to party_candidate__content css file. 
I know there was intention to have some behaviour generic with avatar-list serving parties and candidates. 
I'm up to spend some time figuring out why for candidates the hover property was being ignored, but due to time constraints adding a simple hover property to party_candidate__content doesn't seem a bad idea. 