### PR TITLE
Force HTTPS at the app level

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,6 @@ Rails.application.configure do
 
   # Web console
   config.web_console.permissions = '192.168.128.0/24'
+
+  config.force_ssl = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Fixes #111

[Heroku documentation](https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls)