### PR TITLE
Add sidebar in manifesto page to share content

### DIFF
--- a/app/assets/stylesheets/pages/party-manifesto/party-manifesto.scss
+++ b/app/assets/stylesheets/pages/party-manifesto/party-manifesto.scss
@@ -177,3 +177,17 @@ section.party-manifesto-body {
         }
     }
 }
+
+.party-manifesto-item {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 10px;
+}
+
+.party-manifesto-item__bar {
+    flex: 0 0 5px;
+    margin-right: 10px;
+    background-color: black;
+    cursor: pointer;
+}

--- a/app/javascript/components/party/party-manifestos/ManifestoSection.js
+++ b/app/javascript/components/party/party-manifestos/ManifestoSection.js
@@ -1,4 +1,5 @@
 import React, { PureComponent, Fragment } from "react";
+import PropTypes from "prop-types";
 import { Tooltip } from "antd";
 import ReactHtmlParser from 'react-html-parser';
 import Popover from "react-text-selection-popover";
@@ -11,18 +12,40 @@ class ManifestoSection extends PureComponent {
         this.sectionContentRef = React.createRef();
     }
 
-    onClickTwitterShare(e) {
+    static propTypes = {
+        title: PropTypes.string,
+        section: PropTypes.object,
+        section_id: PropTypes.string,
+        party_acronym: PropTypes.string
+    }
+
+    onClickTwitterShare(e, id) {
         e.preventDefault();
-        const text = window.getSelection().toString();
+
+        const { section_id, party_acronym } = this.props;
+        const text = `https://www.politicaparatodos.pt/party/${party_acronym}/manifesto/${section_id}%23${id}`;
+        console.log(text);
         window.open(`https://twitter.com/intent/tweet?text=${text}`, "Twitter", "height=285,width=550,resizable=1");
         e.stopPropagation();
     }
 
-    renderSectionItem(item) {
+    renderTooltipContent() {
         return (
-            <Fragment key={item.id}>
+            <div onClick={(e) => this.onClickTwitterShare(e)}>
+                <img src={twitterImg} />
+            </div>
+        )
+    }
+    renderSectionItem(item) {
+        if (item.content.length === 1) {
+            return null;
+        }
+
+        return (
+            <div key={item.id} id={item.id} className="party-manifesto-item">
+                <div className="party-manifesto-item__bar" onClick={(e) => this.onClickTwitterShare(e, item.id)}></div>
                 {ReactHtmlParser(item.content)}
-            </Fragment>
+            </div>
         );
     }
 
@@ -54,18 +77,9 @@ class ManifestoSection extends PureComponent {
                 <h1 className="party-manifesto-body__title">{title}</h1>
                 {this.renderSectionTitle()}
                 <div
-                    ref={this.sectionContentRef}
                     className="party-manifesto-body__content">
                     {this.renderSectionContent()}
                 </div>
-                <Popover
-                    selectionRef={this.sectionContentRef}
-                    className="party-manifesto__share-popover">
-                    <div className="party-manifesto__share-popover-inner"
-                        onClick={(e) => this.onClickTwitterShare(e)}>
-                        <img src={twitterImg} />
-                    </div>
-                </Popover>
             </section>
         )
     }

--- a/app/javascript/components/party/party-manifestos/index.js
+++ b/app/javascript/components/party/party-manifestos/index.js
@@ -133,7 +133,7 @@ class PartyManifesto extends PureComponent {
                         </Sider>
                         <Layout.Content>
                             {section && (
-                                <ManifestoSection title={title} section={section} section_id={section_id} />
+                                <ManifestoSection title={title} section={section} section_id={section_id} party_acronym={party_acronym} />
                             )}
                         </Layout.Content>
                     </Layout>


### PR DESCRIPTION
In this commit, we add the sidebar next to each manifesto item to share that item on twitter.
Currently, the twitter text contains the link to the manifesto section.
In my opinion, I think that isn't clear for users that they click on the sidebar to share some content on twitter.

What is your opinion?

![image](https://user-images.githubusercontent.com/1250918/65883305-ac794280-e38e-11e9-9a32-3b4895fdd05c.png)

![image](https://user-images.githubusercontent.com/1250918/65883545-2e696b80-e38f-11e9-85df-aa7754f1450e.png)

