### PR TITLE
Adiciona debates 2022 (página e navegação)

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -8,3 +8,4 @@
 @import './pages/party-candidates/party-candidates';
 @import './pages/party-manifesto/party-manifesto';
 @import './pages/about-us/about-us';
+@import './pages/debates/debates';

--- a/app/assets/stylesheets/pages/debates/debates.scss
+++ b/app/assets/stylesheets/pages/debates/debates.scss
@@ -1,0 +1,7 @@
+.debates_list {
+    padding: 50px 30px;
+}
+
+.debates__table {
+    margin: 30px 0;
+}

--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -22,6 +22,7 @@ import Party from "./party";
 import PartyCandidate from "./party/party-candidates";
 import PartyManifesto from "./party/party-manifestos";
 import AboutUs from './about-us';
+import Debates from './debates';
 
 class App extends React.Component {
     constructor() {
@@ -35,6 +36,7 @@ class App extends React.Component {
                 <Route exact path="/party/:party_acronym" component={withRouter(Party)} />
                 <Route exact path="/party/:party_acronym/candidates/:district" component={withRouter(PartyCandidate)} />
                 <Route exact path="/party/:party_acronym/manifesto/:section_id?" component={withRouter(PartyManifesto)} />
+                <Route exact path="/debates-2022" component={Debates} />
                 <Route exact path="/about-us" component={AboutUs} />
             </Switch >
         )

--- a/app/javascript/components/common/LayoutHeader.js
+++ b/app/javascript/components/common/LayoutHeader.js
@@ -78,13 +78,16 @@ class LayoutHeader extends PureComponent {
                                 <img className="header_logo" src={burger_image} />
                             </Button>
 
-                            <div className="header__desktop-menu">
+                            <nav className="header__desktop-menu">
                                 <Menu mode="horizontal">
                                     <Menu.Item>
                                         <Link to="/" onClick={this.closeDrawer}>Home</Link>
                                     </Menu.Item>
                                     <Menu.Item onClick={this.closeDrawer}>
                                         <HashLink smooth to="/#parties-section" onClick={this.closeDrawer}>Partidos</HashLink>
+                                    </Menu.Item>
+                                    <Menu.Item>
+                                        <Link to="/debates-2022" onClick={this.closeDrawer}>Debates 2022</Link>
                                     </Menu.Item>
                                     <Menu.Item>
                                         <Link to="/about-us" onClick={this.closeDrawer}>Quem Somos</Link>
@@ -99,7 +102,7 @@ class LayoutHeader extends PureComponent {
                                 <div className="header-social-media">
                                     <SocialSharing socialMediaList={socialSharing} />
                                 </div>
-                            </div>
+                            </nav>
                         </Col>
                     </Row>
                     <Drawer

--- a/app/javascript/components/debates/debates.js
+++ b/app/javascript/components/debates/debates.js
@@ -1,0 +1,218 @@
+export const columns = [
+    {
+        title: "Data",
+        dataIndex: "data",
+        key: "data",
+    },
+    {
+        title: "Partidos",
+        dataIndex: "partidos",
+        key: "partidos",
+    },
+    {
+        title: "Canal",
+        dataIndex: "canal",
+        key: "canal",
+    },
+]
+
+export const data = [
+    {
+        key: "1",
+        data: "2 de Janeiro",
+        partidos: "PS x Livre",
+        canal: "RTP1/RTP3"
+    },
+    {
+        key: "2",
+        data: "2 de Janeiro",
+        partidos: "BE x Chega",
+        canal: "SIC Notícias"
+    },
+    {
+        key: "3",
+        data: "3 de Janeiro",
+        partidos: "PSD x Chega",
+        canal: "SIC"
+    },
+    {
+        key: "4",
+        data: "4 de Janeiro",
+        partidos: "BE x Livre",
+        canal: "SIC Notícias"
+    },
+    {
+        key: "5",
+        data: "4 de Janeiro",
+        partidos: "PS x CDU",
+        canal: "TVI"
+    },
+    {
+        key: "6",
+        data: "4 de Janeiro",
+        partidos: "CDS x PAN",
+        canal: "RTP3"
+    },
+    {
+        key: "7",
+        data: "5 de Janeiro",
+        partidos: "CDS x IL",
+        canal: "RTP3"
+    },
+    {
+        key: "8",
+        data: "5 de Janeiro",
+        partidos: "PSD x BE",
+        canal: "SIC"
+    },
+    {
+        key: "9",
+        data: "5 de Janeiro",
+        partidos: "Chega x Livre",
+        canal: "CNN Portugal"
+    },
+    {
+        key: "10",
+        data: "6 de Janeiro",
+        partidos: "PS x Chega",
+        canal: "RTP1/RTP3"
+    },
+    {
+        key: "11",
+        data: "6 de Janeiro",
+        partidos: "BE x IL",
+        canal: "SIC Notícias"
+    },
+    {
+        key: "21",
+        data: "7 de Janeiro",
+        partidos: "IL x PAN",
+        canal: "SIC Notícias"
+    },
+    {
+        key: "12",
+        data: "7 de Janeiro",
+        partidos: "PSD x CDS",
+        canal: "TVI"
+    },
+    {
+        key: "13",
+        data: "8 de Janeiro",
+        partidos: "PS x PAN",
+        canal: "TVI"
+    },
+    {
+        key: "14",
+        data: "8 de Janeiro",
+        partidos: "PSD x Livre",
+        canal: "RTP1/RTP3"
+    },
+    {
+        key: "15",
+        data: "9 de Janeiro",
+        partidos: "PS x CDS",
+        canal: "SIC"
+    },
+    {
+        key: "16",
+        data: "9 de Janeiro",
+        partidos: "IL x Chega",
+        canal: "RTP3"
+    },
+    {
+        key: "17",
+        data: "9 de Janeiro",
+        partidos: "PAN x Livre",
+        canal: "SIC Notícias"
+    },
+    {
+        key: "18",
+        data: "10 de Janeiro",
+        partidos: "BE x PAN",
+        canal: "RTP3"
+    },
+    {
+        key: "19",
+        data: "10 de Janeiro",
+        partidos: "PSD x IL",
+        canal: "SIC"
+    },
+    {
+        key: "20",
+        data: "10 de Janeiro",
+        partidos: "CDS x Livre",
+        canal: "CNN"
+    },
+    {
+        key: "22",
+        data: "11 de Janeiro",
+        partidos: "PS x BE",
+        canal: "RTP1/RTP3"
+    },
+    {
+        key: "23",
+        data: "12 de Janeiro",
+        partidos: "CDS x Chega",
+        canal: "CNN"
+    },
+    {
+        key: "24",
+        data: "12 de Janeiro",
+        partidos: "PSD x CDU",
+        canal: "SIC"
+    },
+    {
+        key: "25",
+        data: "12 de Janeiro",
+        partidos: "IL x Livre",
+        canal: "SIC Notícias"
+    },
+    {
+        key: "26",
+        data: "13 de Janeiro",
+        partidos: "PS x PSD",
+        canal: "RTP1/SIC/TVI"
+    },
+    {
+        key: "27",
+        data: "14 de Janeiro",
+        partidos: "PAN x Chega",
+        canal: "SIC Notícias"
+    },
+    {
+        key: "28",
+        data: "14 de Janeiro",
+        partidos: "PS x IL",
+        canal: "TVI"
+    },
+    {
+        key: "29",
+        data: "14 de Janeiro",
+        partidos: "BE x CDS",
+        canal: "RTP3"
+    },
+    {
+        key: "30",
+        data: "15 de Janeiro",
+        partidos: "PSD x PAN",
+        canal: "RTP1/RTP3"
+    },
+    {
+        key: "31",
+        data: "17 de Janeiro",
+        partidos: "Partidos com assento parlamentar (incluindo Livre)",
+        canal: "RTP1/RTP3"
+    },
+    {
+        key: "32",
+        data: "18 de Janeiro",
+        partidos: "Partidos sem assento parlamentar",
+        canal: "RTP1/RTP3"
+    },
+    {
+        key: "33",
+        data: "20 de Janeiro",
+        partidos: "Partidos com assento parlamentar (incluindo Livre)",
+        canal: "RR/Antena1/TSF"
+    },
+]

--- a/app/javascript/components/debates/index.js
+++ b/app/javascript/components/debates/index.js
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 Politica para Todos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { Layout, Icon, Row, Col, Alert, Table, Card } from 'antd';
+import MetaTags from "../MetaTags";
+import LayoutHeader from "../common/LayoutHeader";
+import LayoutFooter from "../common/LayoutFooter";
+
+import { columns, data } from "./debates";
+
+export default function Debates() {
+    return (
+        <Layout>
+            <MetaTags
+                pageTitle="Debates Legilativas 2022"
+                pageDescription="A comunidade Política Para Todos nasceu no verão de 2019 com o objetivo de promover a participação ativa dos cidadãos nos processos eleitorais em Portugal. É composta por voluntários de várias partes do país e diferentes áreas profissionais."
+                socialTitle="Debates Legilativas 2022"
+                socialDescription="A comunidade Política Para Todos nasceu no verão de 2019 com o objetivo de promover a participação ativa dos cidadãos nos processos eleitorais em Portugal. É composta por voluntários de várias partes do país e diferentes áreas profissionais."
+                socialImage="/images/share/banner-PPT.jpg"
+            />
+            <LayoutHeader />
+            <Layout.Content>
+                <section className="debates">
+                    <Row type="flex" justify="space-between" align="middle">
+                        <Col span={24} lg={24} className="home-our-mission-text">
+                            <Alert
+                                message="Atenção"
+                                description="Esta é a programação conhecida de momento. A agenda poderá ser alterada pelos partidos e televisões."
+                                type="info"
+                            />
+                        </Col>
+                    </Row>
+                    <Row type="flex" justify="space-between" align="middle" className="debates_list">
+                        <Col span={24} lg={24} className="home-our-mission-text">
+                            <h1>Debates televisivos</h1>
+                            <p>Participam nos debates televisivos todos os partidos que, nas últimas eleições Legislativas (2019), conquistaram lugares parlamentares em várias rondas frente a frente. No final, ainda serão realizados dois debates com todos os partidos eleitos em 2019 (televisão e rádio) e outro com partidos não eleitos há dois anos.</p>
+                            <p>Subscreve o nosso calendário com horários dos debates actualizados: <a target="_blank" rel="noreferrer" rel="noopener" href="https://bit.ly/debates22-PPT">Calendário Google de debates 2022 <Icon type="link" /></a></p>
+                            <Table dataSource={data} columns={columns} className="debates__table" />
+                            <Card title="Perdeste um debate?">
+                                <p>A RTP Play disponibiliza todos os debates independentemente do canal que tenha exibido. Aproveita para rever o debate que procuras:</p>
+                                <ul>
+                                    <li>
+                                        <a href="https://www.rtp.pt/play/p9711/legislativas-2022-debates-rtp" target="_blank" rel="noreferrer" rel="noopener">Debates RTP/RTP3 <Icon type="link" /></a>
+                                    </li>
+                                    <li>
+                                        <a href="https://www.rtp.pt/play/p9787/legislativas-2022-debates-sic-sic-noticias" target="_blank" rel="noreferrer" rel="noopener">Debates SIC/SIC Notícias <Icon type="link" /></a>
+                                    </li>
+                                    <li>
+                                        <a href="https://www.rtp.pt/play/p9788/legislativas-2022-debates-tvi-cnn" target="_blank" rel="noreferrer" rel="noopener">Debates TVI/CNN Portugal <Icon type="link" /></a>
+                                    </li>
+                                    <li>
+                                        <a href="https://www.rtp.pt/play/p9596/eleicoes-legislativas-2022-entrevistas-lideres-partidarios" target="_blank" rel="noreferrer" rel="noopener">Entrevista a lideres partidários <Icon type="link" /></a>
+                                    </li>
+                                </ul>
+                            </Card>
+                        </Col>
+                    </Row>
+                </section>
+            </Layout.Content>
+            <LayoutFooter />
+        </Layout>
+    );
+}


### PR DESCRIPTION
Adiciona página dos debates de 2022 com links para a RTP Play (que tem todos os debates de todos os canais). Adiciona também link na navegação principal.

![Screenshot 2022-01-09 at 17 32 29](https://user-images.githubusercontent.com/19707842/148693564-4a883fbc-b282-4aad-8fa1-cbbf3cced8f5.png)

